### PR TITLE
Transfer repo to the 'fcrepo-exts' GitHub org

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,4 +35,4 @@ Example:
 * Could this change impact execution of existing code?
 
 # Interested parties
-Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
+Tag (@ mention) interested parties or, if unsure, @fcrepo/committers

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The **fcrepo:** component provides access to an external
 [API](https://wiki.duraspace.org/display/FEDORA5x/RESTful+HTTP+API+-+Containers)
 for use with [Apache Camel](https://camel.apache.org).
 
-[![Build Status](https://travis-ci.com/fcrepo4-exts/fcrepo-camel.svg?branch=master)](https://travis-ci.com/fcrepo4-exts/fcrepo-camel)
+[![Build Status](https://travis-ci.com/fcrepo-exts/fcrepo-camel.svg?branch=master)](https://travis-ci.com/fcrepo-exts/fcrepo-camel)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.fcrepo.camel/fcrepo-camel/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.fcrepo.camel/fcrepo-camel/)
 
 URI format
@@ -341,7 +341,7 @@ If you don't need further access to the message body, it is possible to omit the
 Examples and more information
 -----------------------------
 
-For projects that use `fcrepo-camel`, please refer to the [`fcrepo-camel-toolbox`](https://github.com/fcrepo4-exts/fcrepo-camel-toolbox) project.
+For projects that use `fcrepo-camel`, please refer to the [`fcrepo-camel-toolbox`](https://github.com/fcrepo-exts/fcrepo-camel-toolbox) project.
 
 Furthermore, additional information about designing and deploying **fcrepo**-based message routes along
 with configuration options for Fedora's ActiveMQ broker can be found on the

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <project.copyrightYear>2015</project.copyrightYear>
 
     <!-- Use ${project_name} instead of ${project.artifactId} to avoid incorrect
-      replacements of "fcrepo4" in child modules (for scm, site-distribution, etc -->
+      replacements of "fcrepo" in child modules (for scm, site-distribution, etc -->
     <project_name>fcrepo-camel</project_name>
 
     <!-- https://github.com/github/maven-plugins/blob/master/README.md -->
@@ -71,9 +71,9 @@
   </properties>
 
   <scm>
-    <connection>scm:git:git://github.com/fcrepo4-exts/${project_name}.git</connection>
-    <developerConnection>scm:git:git@github.com:fcrepo4-exts/${project_name}.git</developerConnection>
-    <url>https://github.com/fcrepo4-exts/fcrepo-camel</url>
+    <connection>scm:git:git://github.com/fcrepo-exts/${project_name}.git</connection>
+    <developerConnection>scm:git:git@github.com:fcrepo-exts/${project_name}.git</developerConnection>
+    <url>https://github.com/fcrepo-exts/fcrepo-camel</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -555,7 +555,7 @@
 
   <issueManagement>
     <system>GitHub</system>
-    <url>https://github.com/fcrepo4-exts/fcrepo-camel/issues</url>
+    <url>https://github.com/fcrepo-exts/fcrepo-camel/issues</url>
   </issueManagement>
 
   <ciManagement>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -14,8 +14,8 @@
   <body>
     <links>
       <item name="Fedora" href="http://fcrepo.org/" />
-      <item name="fcrepo-camel Compontent on GitHub" href="http://github.com/fcrepo4-exts/fcrepo-camel" />
-      <item name="Developer Documentation" href="http://fcrepo4-exts.github.com/fcrepo-camel/" />
+      <item name="fcrepo-camel Compontent on GitHub" href="http://github.com/fcrepo-exts/fcrepo-camel" />
+      <item name="Developer Documentation" href="http://fcrepo-exts.github.com/fcrepo-camel/" />
     </links>
 
     <breadcrumbs>


### PR DESCRIPTION
No functional changes.
# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
