### PR TITLE
updating actions/cache github action as v2 is being deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         java-version: 11
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
**Bumping actions/cache in GH actions due to deprecation**
* * *

**JIRA Ticket**: https://github.com/actions/toolkit/tree/main/packages/cache

# How should this be tested?

A description of what steps someone could take to:

Check GH Actions still run as expected. The action is supposedly backwards compatible so no issues are expected

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
